### PR TITLE
Add kernel interrupt and restart functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,27 @@ Example usage:
 :MagmaShowOutput
 ```
 
+#### MagmaInterrupt
+
+Send a keyboard interrupt to the kernel. Interrupts the currently running cell and does nothing if not
+cell is running.
+
+Example usage:
+
+```vim
+:MagmaInterrupt
+```
+
+#### MagmaRestart
+
+Shuts down and restarts the current kernel.
+
+Example usage:
+
+```vim
+:MagmaRestart
+```
+
 #### MagmaSave
 
 Save the current cells and evaluated outputs into a JSON file, which can then be loaded back with [`:MagmaLoad`](#magmaload).

--- a/README.md
+++ b/README.md
@@ -185,10 +185,18 @@ Example usage:
 
 Shuts down and restarts the current kernel.
 
+Optionally deletes all output if used with a bang.
+
 Example usage:
 
 ```vim
 :MagmaRestart
+```
+
+Example usage (also deleting outputs):
+
+```vim
+:MagmaRestart!
 ```
 
 #### MagmaSave

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -209,6 +209,22 @@ class Magma:
 
         magma.reevaluate_cell()
 
+    @pynvim.command("MagmaInterrupt", nargs=0, sync=True)
+    @nvimui
+    def command_interrupt(self) -> None:
+        magma = self._get_magma(True)
+        assert magma is not None
+
+        magma.interrupt()
+
+    @pynvim.command("MagmaRestart", nargs=0, sync=True)
+    @nvimui
+    def command_restart(self) -> None:
+        magma = self._get_magma(True)
+        assert magma is not None
+
+        magma.restart()
+
     @pynvim.command("MagmaDelete", nargs=0, sync=True)
     @nvimui
     def command_delete(self) -> None:

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -217,13 +217,13 @@ class Magma:
 
         magma.interrupt()
 
-    @pynvim.command("MagmaRestart", nargs=0, sync=True)
+    @pynvim.command("MagmaRestart", nargs=0, sync=True, bang=True)
     @nvimui
-    def command_restart(self) -> None:
+    def command_restart(self, bang: bool) -> None:
         magma = self._get_magma(True)
         assert magma is not None
 
-        magma.restart()
+        magma.restart(delete_outputs=bang)
 
     @pynvim.command("MagmaDelete", nargs=0, sync=True)
     @nvimui

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -75,6 +75,12 @@ class MagmaBuffer:
         self.runtime.deinit()
         self._doautocmd('MagmaDeinitPost')
 
+    def interrupt(self) -> None:
+        self.runtime.interrupt()
+
+    def restart(self) -> None:
+        self.runtime.restart()
+
     def _buffer_to_window_lineno(self, lineno: int) -> int:
         win_top = self.nvim.funcs.line('w0')
         return lineno - win_top + 1

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -79,9 +79,11 @@ class MagmaBuffer:
         self.runtime.interrupt()
 
     def restart(self, delete_outputs: bool=False) -> None:
-        self.runtime.restart()
         if delete_outputs:
             self.outputs = {}
+            self.clear_interface()
+
+        self.runtime.restart()
 
     def _buffer_to_window_lineno(self, lineno: int) -> int:
         win_top = self.nvim.funcs.line('w0')

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -78,8 +78,10 @@ class MagmaBuffer:
     def interrupt(self) -> None:
         self.runtime.interrupt()
 
-    def restart(self) -> None:
+    def restart(self, delete_outputs: bool=False) -> None:
         self.runtime.restart()
+        if delete_outputs:
+            self.outputs = {}
 
     def _buffer_to_window_lineno(self, lineno: int) -> int:
         win_top = self.nvim.funcs.line('w0')

--- a/rplugin/python3/magma/runtime.py
+++ b/rplugin/python3/magma/runtime.py
@@ -52,6 +52,13 @@ class JupyterRuntime:
 
         self.kernel_client.shutdown()
 
+    def interrupt(self):
+        self.kernel_manager.interrupt_kernel()
+
+    def restart(self):
+        self.state = RuntimeState.STARTING
+        self.kernel_manager.restart_kernel()
+
     def run_code(self, code: str) -> Output:
         self.kernel_client.execute(code)
 


### PR DESCRIPTION
Fixes #34 

This adds two new commands, `MagmaInterrupt` which sends a `SIGINT` to the kernel, and `MagmaRestart` which completely restarts the kernel.

It may be worth to discuss whether `MagmaRestart` should also clear all output.