### PR TITLE
perf: cursor move events only redraw when changed

### DIFF
--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -55,9 +55,9 @@ class Magma:
 
     def _set_autocommands(self) -> None:
         self.nvim.command("augroup magma")
-        self.nvim.command("  autocmd CursorMoved  * call MagmaUpdateInterface()")
-        self.nvim.command("  autocmd CursorMovedI * call MagmaUpdateInterface()")
-        self.nvim.command("  autocmd WinScrolled  * call MagmaUpdateInterface()")
+        self.nvim.command("  autocmd CursorMoved  * call MagmaOnCursorMoved()")
+        self.nvim.command("  autocmd CursorMovedI * call MagmaOnCursorMoved()")
+        self.nvim.command("  autocmd WinScrolled  * call MagmaOnWinScrolled()")
         self.nvim.command("  autocmd BufEnter     * call MagmaUpdateInterface()")
         self.nvim.command("  autocmd BufLeave     * call MagmaClearInterface()")
         self.nvim.command("  autocmd BufUnload    * call MagmaOnBufferUnload()")
@@ -99,6 +99,16 @@ class Magma:
             return
 
         magma.update_interface()
+
+    def _on_cursor_moved(self, scrolled=False) -> None:
+        if not self.initialized:
+            return
+
+        magma = self._get_magma(False)
+        if magma is None:
+            return
+
+        magma.on_cursor_moved(scrolled)
 
     def _ask_for_choice(self, preface: str, options: List[str]) -> str:
         index = self.nvim.funcs.inputlist(
@@ -343,6 +353,16 @@ class Magma:
     @nvimui
     def function_update_interface(self, _) -> None:
         self._update_interface()
+
+    @pynvim.function("MagmaOnCursorMoved", sync=True)
+    @nvimui
+    def function_on_cursor_moved(self, _) -> None:
+        self._on_cursor_moved()
+
+    @pynvim.function("MagmaOnWinScrolled", sync=True)
+    @nvimui
+    def function_on_win_scrolled(self, _) -> None:
+        self._on_cursor_moved(scrolled=True)
 
     @pynvim.function("MagmaOperatorfunc", sync=True)
     @nvimui

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -264,6 +264,21 @@ class MagmaBuffer:
 
         self.updating_interface = False
 
+    def on_cursor_moved(self, scrolled=False) -> None:
+        selected_cell = self._get_selected_span()
+
+        if self.selected_cell == selected_cell and selected_cell is not None:
+            if selected_cell.end.lineno < self.nvim.funcs.line("w$") and self.should_open_display_window and scrolled:
+                if self.display_window is not None: # and self.nvim.funcs.winbufnr(self.display_window) != -1:
+                    self.nvim.funcs.nvim_win_close(self.display_window, True)
+                    self.canvas.clear()
+                    self.display_window = None
+                self._show_outputs(self.outputs[selected_cell], selected_cell.end)
+                self.canvas.present()
+            return
+
+        self.update_interface()
+
     def _show_selected(self, span: Span) -> None:
         if span.begin.lineno == span.end.lineno:
             self.nvim.funcs.nvim_buf_add_highlight(


### PR DESCRIPTION
This PR adds a new function to handle `CursorMoved` and `WinScrolled`. On `CursorMoved` it only rehighlights when the cursor left the cell, `WinScrolled` only redraws the output if the end of the cell is in the visible range of the window.