### PR TITLE
Ability to Connect to already running Kernels

### DIFF
--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -161,7 +161,7 @@ class Magma:
             kernel_name = args[0]
             self._initialize_buffer(kernel_name)
         else:
-            PROMPT = "Select the kernel to launch!:"
+            PROMPT = "Select the kernel to launch:"
             available_kernels = get_available_kernels()
             if self.nvim.exec_lua("return vim.ui.select ~= nil"):
                 self.nvim.exec_lua(

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,14 +152,6 @@ class Magma:
 
         return magma
 
-    @pynvim.command("MagmaConnect", nargs="?", sync=True)  # type: ignore
-    @nvimui  # type: ignore
-    def command_init(self, args: List[str]) -> None:
-        self._initialize_if_necessary()
-        if args:
-            kernel_path = args[0]
-            self._initialize_buffer(kernel_path)
-
     @pynvim.command("MagmaInit", nargs="?", sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:
@@ -169,7 +161,7 @@ class Magma:
             kernel_name = args[0]
             self._initialize_buffer(kernel_name)
         else:
-            PROMPT = "Select the kernel to launch:"
+            PROMPT = "Select the kernel to launch!:"
             available_kernels = get_available_kernels()
             if self.nvim.exec_lua("return vim.ui.select ~= nil"):
                 self.nvim.exec_lua(

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,6 +152,14 @@ class Magma:
 
         return magma
 
+    @pynvim.command("MagmaConnect", nargs="?", sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def command_init(self, args: List[str]) -> None:
+        self._initialize_if_necessary()
+        if args:
+            kernel_path = args[0]
+            self._initialize_buffer(kernel_path)
+
     @pynvim.command("MagmaInit", nargs="?", sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:

--- a/rplugin/python3/magma/runtime.py
+++ b/rplugin/python3/magma/runtime.py
@@ -70,8 +70,6 @@ class JupyterRuntime:
             self.kernel_client = self.kernel_manager.client()
 
             self.kernel_client.load_connection_file(connection_file=kernel_file)
-            # connect to it
-            # self.kernel_client.start_channels()
 
             self.allocated_files = []
 
@@ -126,14 +124,13 @@ class JupyterRuntime:
 
         if message_type == "execute_input":
             output.execution_count = content["execution_count"]
-            assert output.status != OutputStatus.DONE
-            if output.status == OutputStatus.HOLD:
-                output.status = OutputStatus.RUNNING
-            elif output.status == OutputStatus.RUNNING:
-                output.status = OutputStatus.DONE
-            else:
-                if self.external_kernel == False:
-                    print("External Kernel: ", self.external_kernel)
+            if self.external_kernel == False:
+                assert output.status != OutputStatus.DONE
+                if output.status == OutputStatus.HOLD:
+                    output.status = OutputStatus.RUNNING
+                elif output.status == OutputStatus.RUNNING:
+                    output.status = OutputStatus.DONE
+                else:
                     raise ValueError(
                         "bad value for output.status: %r" % output.status
                     )

--- a/rplugin/python3/magma/runtime.py
+++ b/rplugin/python3/magma/runtime.py
@@ -85,7 +85,8 @@ class JupyterRuntime:
             if os.path.exists(path):
                 os.remove(path)
 
-        self.kernel_client.shutdown()
+        if self.external_kernel is False:
+            self.kernel_client.shutdown()
 
     def interrupt(self) -> None:
         self.kernel_manager.interrupt_kernel()


### PR DESCRIPTION
I am working on adding the ability to connect to already running Kernels. My main motivation for this because [the output window gets stuck](https://github.com/dccsillag/magma-nvim/issues/68) and makes me have to restart my nvim session (effectively restarting my Kernel). This is a bit frustrating... so I thought I'd add the ability to start the kernel independently. 

Start a Kernel
```bash
jupyter console --kernel=julia-1.8 -f /tmp/julia.json
```

in nvim connect to it by `:MagmaInit /tmp/julia.json`

Currently this works ~~**BUT** there are two big problems I am facing with this~~. 

1. ~~You have an error check to see if there's missed output from Jupyter~~. ~~If you use the external console it will trip this~~.. ~~I'm still trying to understand whats going on there so I can modify things to not trip~~..
2. ~~Seems if you close nvim the kernel still closes~~. ~~I am not sure if this is a "feature" of Jupyter or if you have some dead man switch somewhere~~. 