### PR TITLE
Adding a new command for evaluating in line and instructions for other kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Magma is a NeoVim plugin for running code interactively with Jupyter.
     - [`cairosvg`](https://cairosvg.org/) (for displaying SVG images)
     - [`pnglatex`](https://pypi.org/project/pnglatex/) (for displaying TeX formulas)
     - `plotly` and `kaleido` (for displaying Plotly figures)
+- For .NET (C#, F#)
+    - `dotnet tool install -g Microsoft.dotnet-interactive`
+    - `dotnet interactive jupyter install`
 
 You can do a `:checkhealth` to see if you are ready to go.
 
@@ -58,6 +61,37 @@ let g:magma_image_provider = "ueberzug"
 **Note:** Key mappings are not defined by default because of potential conflicts -- the user should decide which keys they want to use (if at all).
 
 **Note:** The options that are altered here don't have these as their default values in order to provide a simpler (albeit perhaps a bit more inconvenient) UI for someone who just added the plugin without properly reading the README.
+
+To make initialisation of kernels easier, you can add these commands:
+
+```lua
+function MagmaInitPython()
+    vim.cmd[[
+    :MagmaInit python3
+    :MagmaEvaluateArgument a=5
+    ]]
+end
+
+function MagmaInitCSharp()
+    vim.cmd[[
+    :MagmaInit .net-csharp
+    :MagmaEvaluateArgument Microsoft.DotNet.Interactive.Formatting.Formatter.SetPreferredMimeTypesFor(typeof(System.Object),"text/plain");
+    ]]
+end
+
+function MagmaInitFSharp()
+    vim.cmd[[
+    :MagmaInit .net-fsharp
+    :MagmaEvaluateArgument Microsoft.DotNet.Interactive.Formatting.Formatter.SetPreferredMimeTypesFor(typeof<System.Object>,"text/plain")
+    ]]
+end
+
+vim.cmd[[
+:command MagmaInitPython lua MagmaInitPython()
+:command MagmaInitCSharp lua MagmaInitCSharp()
+:command MagmaInitFSharp lua MagmaInitFSharp()
+]]
+```
 
 ## Usage
 
@@ -140,6 +174,14 @@ nnoremap <expr> <LocalLeader>r nvim_exec('MagmaEvaluateOperator', v:true)
 ```
 
 Upon using this mapping, you will enter operator mode, with which you will be able to select text you want to execute. You can, of course, hit ESC to cancel, as usual with operator mode.
+
+#### MagmaEvaluateArgument
+
+Evaluate the text following this command. Could be used for some automation (e. g. run something on initialization of a kernel).
+
+```vim
+:MagmaEvaluateArgument a=5;
+```
 
 #### MagmaReevaluateCell
 

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -223,12 +223,30 @@ class Magma:
 
         magma.run_code(code, span)
 
+    def _do_evaluate_expr(self, expr):
+        self._initialize_if_necessary()
+
+        magma = self._get_magma(True)
+        assert magma is not None
+        bufno = self.nvim.current.buffer.number
+        span = Span(
+            DynamicPosition(self.nvim, self.extmark_namespace, bufno, 0, 0),
+            DynamicPosition(self.nvim, self.extmark_namespace, bufno, 0, 0),
+        )
+        magma.run_code(expr, span)
+
     @pynvim.command("MagmaEnterOutput", sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_enter_output_window(self) -> None:
         magma = self._get_magma(True)
         assert magma is not None
         magma.enter_output()
+
+    @pynvim.command("MagmaEvaluateArgument", nargs=1, sync=True)
+    @nvimui
+    def commnand_magma_evaluate_argument(self, expr) -> None:
+        assert len(expr) == 1
+        self._do_evaluate_expr(expr[0])
 
     @pynvim.command("MagmaEvaluateVisual", sync=True)  # type: ignore
     @nvimui  # type: ignore

--- a/rplugin/python3/magma/runtime.py
+++ b/rplugin/python3/magma/runtime.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from queue import Empty as EmptyQueueException
 import os
 import tempfile
+import json
 
 import jupyter_client
 
@@ -39,20 +40,40 @@ class JupyterRuntime:
         self.state = RuntimeState.STARTING
         self.kernel_name = kernel_name
 
-        self.kernel_manager = jupyter_client.manager.KernelManager(
-            kernel_name=kernel_name
-        )
-        self.kernel_manager.start_kernel()
-        self.kernel_client = self.kernel_manager.client()
-        assert isinstance(
-            self.kernel_client,
-            jupyter_client.blocking.client.BlockingKernelClient,
-        )
-        self.kernel_client.start_channels()
+        if ".json" not in self.kernel_name:
 
-        self.allocated_files = []
+            self.external_kernel = True
+            self.kernel_manager = jupyter_client.manager.KernelManager(
+                kernel_name=kernel_name
+            )
+            self.kernel_manager.start_kernel()
+            self.kernel_client = self.kernel_manager.client()
+            assert isinstance(
+                self.kernel_client,
+                jupyter_client.blocking.client.BlockingKernelClient,
+            )
+            self.kernel_client.start_channels()
 
-        self.options = options
+            self.allocated_files = []
+
+            self.options = options
+
+        else:
+            kernel_file = kernel_name
+            self.external_kernel = True
+            # Opening JSON file
+            kernel_json = json.load(open(kernel_file))
+            # we have a kernel json
+            self.kernel_manager = jupyter_client.manager.KernelManager(
+                    kernel_name=kernel_json["kernel_name"]
+                    )
+            self.kernel_client = self.kernel_manager.client()
+
+            self.kernel_client.load_connection_file(connection_file=kernel_file)
+
+            self.allocated_files = []
+
+            self.options = options
 
     def is_ready(self) -> bool:
         return self.state.value > RuntimeState.STARTING.value
@@ -62,7 +83,8 @@ class JupyterRuntime:
             if os.path.exists(path):
                 os.remove(path)
 
-        self.kernel_client.shutdown()
+        if self.external_kernel is False:
+            self.kernel_client.shutdown()
 
     def interrupt(self) -> None:
         self.kernel_manager.interrupt_kernel()
@@ -102,15 +124,16 @@ class JupyterRuntime:
 
         if message_type == "execute_input":
             output.execution_count = content["execution_count"]
-            assert output.status != OutputStatus.DONE
-            if output.status == OutputStatus.HOLD:
-                output.status = OutputStatus.RUNNING
-            elif output.status == OutputStatus.RUNNING:
-                output.status = OutputStatus.DONE
-            else:
-                raise ValueError(
-                    "bad value for output.status: %r" % output.status
-                )
+            if self.external_kernel == False:
+                assert output.status != OutputStatus.DONE
+                if output.status == OutputStatus.HOLD:
+                    output.status = OutputStatus.RUNNING
+                elif output.status == OutputStatus.RUNNING:
+                    output.status = OutputStatus.DONE
+                else:
+                    raise ValueError(
+                        "bad value for output.status: %r" % output.status
+                    )
             return True
         elif message_type == "status":
             execution_state = content["execution_state"]


### PR DESCRIPTION
Closes #74 

Jupyter supports any kernel, not just python's. That makes it usable for other languages, such as C# and F#. To use them, you have to make its output mimetype `text/plain`, that's where we need `MagmaEvaluateArgument`. Example of this command:

```
:MagmaEvaluateArgument a=5;
```

That will assign `5` to variable `a` in current context.


I also added an example of vim commands to add for kernel initialization. That makes it easier to use with, say, telescope. And by default it overwrites mimetype to `text/plain` for C# and F#.

Note that I merged @LoipesMas into my fork to make things easier for myself.