### PR TITLE
Improve tmux detection

### DIFF
--- a/rplugin/python3/magma/images.py
+++ b/rplugin/python3/magma/images.py
@@ -213,7 +213,17 @@ class KittyImage:
             w(payload)
         w(b"\033\\")
         ans = b"".join(ans)  # type: ignore
-        if "tmux" in os.environ["TERM"]:
+        # Mangling the escape codes to make them work inside tmux
+        inside_tmux = (
+            any(os.environ.get("TMUX", ""))
+            or
+            # Only for tmux >= 3.2
+            "tmux" in os.environ.get("TERM_PROGRAM", "")
+            or
+            # Not reliable, TERM can be set to screen-256color, xterm-kitty, etc.
+            "tmux" in os.environ.get("TERM", "")
+        )
+        if inside_tmux:
             ans = b"\033Ptmux;" + ans.replace(b"\033", b"\033\033") + b"\033\\"  # type: ignore
         return ans
 


### PR DESCRIPTION
"tmux" might not always appear in $TERM (info).

Check for "$TMUX" env variable or "tmux" in "$TERM_PROGRAM"

Tested to work when TERM inside tmux is set to "xterm-kitty"