### PR TITLE
`MagmaEvaluateRange` vim function

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,22 @@ We provide some `User` autocommands (see `:help User`) for further customization
 - `MagmaDeinitPre`: runs right before `MagmaDeinit` deinitialization happens for a buffer
 - `MagmaDeinitPost`: runs right after `MagmaDeinit` deinitialization happens for a buffer
 
+## Functions
+
+There is a provided function `MagmaEvaluateRange(start_line, end_line)` which evaluates the code
+between the given line numbers (inclusive). This is intended for use in scripts.
+
+### Example Usage:
+```lua
+vim.fn.MagmaEvaluateRange(1, 23)
+```
+
+```vim
+MagmaEvaluateRange(1, 23)
+" from the command line
+:call MagmaEvaluateRange(1, 23)
+```
+
 ## Extras
 
 ### Output Chunks

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,7 +152,7 @@ class Magma:
 
         return magma
 
-    @pynvim.command("MagmaInit", nargs="?", sync=True, complete='file')  # type: ignore
+    @pynvim.command("MagmaInit", nargs="?", sync=True, complete="file")  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:
         self._initialize_if_necessary()
@@ -265,6 +265,17 @@ class Magma:
             ),
         )
 
+        self._do_evaluate(span)
+
+    @pynvim.function("MagmaEvaluateRange", sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def evaulate_range(self, *args) -> None:
+        # self.nvim.current.line = f"args: {args}"
+        start_line, end_line = args[0]
+        span = (
+            (start_line - 1, 0),
+            (end_line - 1, len(self.nvim.funcs.getline(end_line))),
+        )
         self._do_evaluate(span)
 
     @pynvim.command("MagmaEvaluateOperator", sync=True)  # type: ignore
@@ -487,6 +498,10 @@ class Magma:
             DynamicPosition(
                 self.nvim, self.extmark_namespace, bufno, start - 1, 0
             ),
-            DynamicPosition(self.nvim, self.extmark_namespace, bufno, end - 1, -1),
+            DynamicPosition(
+                self.nvim, self.extmark_namespace, bufno, end - 1, -1
+            ),
         )
-        magma.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)
+        magma.outputs[span] = OutputBuffer(
+            self.nvim, self.canvas, self.options
+        )


### PR DESCRIPTION
Adds `MagmaEvaluateRange` to address #108 and partially address #19 

For an example of why this is useful, I use it [here](https://github.com/benlubas/.dotfiles/blob/c384f364c990a8b459f678fb30d44053a2b6aa39/nvim/lua/benlubas/magma_functions.lua#L37) to run all the code cells above the cursor in a qmd document.

From the README:

## Functions

There is a provided function `MagmaEvaluateRange(start_line, end_line)` which evaluates the code
between the given line numbers (inclusive). This is intended for use in scripts.

### Example Usage:
```lua
vim.fn.MagmaEvaluateRange(1, 23)
```

```vim
MagmaEvaluateRange(1, 23)
" from the command line
:call MagmaEvaluateRange(1, 23)
```