### PR TITLE
feat: `MagmaHideOutput` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ Example usage:
 :MagmaShowOutput
 ```
 
+#### MagmaHideOutput
+
+This closes all currently open output windows
+
+Example usage:
+
+```vim
+:MagmaHideOutput
+```
+
 #### MagmaInterrupt
 
 Send a keyboard interrupt to the kernel. Interrupts the currently running cell and does nothing if not

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -332,6 +332,15 @@ class Magma:
         magma.should_open_display_window = True
         self._update_interface()
 
+    @pynvim.command("MagmaHideOutput", nargs=0, sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def command_hide_output(self) -> None:
+        magma = self._get_magma(True)
+        assert magma is not None
+
+        magma.should_open_display_window = False
+        self._clear_interface()
+
     @pynvim.command("MagmaSave", nargs="?", sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_save(self, args: List[str]) -> None:


### PR DESCRIPTION
addresses #41 by adding the `:MagmaHideOutput` command.

This command hides any currently open output windows if they are open.

If auto show output is true, this feature will close the window until you move the cursor again. It's more useful for those that open their windows manually.