### PR TITLE
Feat: magma_enter_output_behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,13 +273,15 @@ If that parameter is omitted, then one will be automatically generated using the
 
 #### MagmaEnterOutput
 
-Enter the output window, if it is currently open. You must call this as follows:
+Configured with [magma_enter_output_behavior](#gmagma_enter_output_behavior)
+
+Enter/open the output window. You must call this as follows:
 
 ```vim
 :noautocmd MagmaEnterOutput
 ```
 
-This is escpecially useful when you have a long output (or errors) and wish to inspect it.
+This is especially useful when you have a long output (or errors) and wish to inspect it.
 
 ## Keybindings
 
@@ -305,6 +307,14 @@ nnoremap <silent> <LocalLeader>rq :noautocmd MagmaEnterOutput<CR>
 ## Customization
 
 Customization is done via variables.
+
+### `g:magma_enter_output_behavior`
+
+Configures the behavior of [MagmaEnterOutput](#magmaenteroutput)
+
+- `"open_then_enter"` (default) -- open the window if it's closed. Enter the window if it's already open
+- `"open_and_enter"` -- open and enter the window if it's closed. Otherwise enter as normal
+- `"no_open"` -- enter the window when it's open, do nothing if it's closed
 
 ### `g:magma_image_provider`
 

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,7 +152,7 @@ class Magma:
 
         return magma
 
-    @pynvim.command("MagmaInit", nargs="?", sync=True, complete="file")  # type: ignore
+    @pynvim.command("MagmaInit", nargs="?", sync=True, complete='file')  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:
         self._initialize_if_necessary()
@@ -265,17 +265,6 @@ class Magma:
             ),
         )
 
-        self._do_evaluate(span)
-
-    @pynvim.function("MagmaEvaluateRange", sync=True)  # type: ignore
-    @nvimui  # type: ignore
-    def evaulate_range(self, *args) -> None:
-        # self.nvim.current.line = f"args: {args}"
-        start_line, end_line = args[0]
-        span = (
-            (start_line - 1, 0),
-            (end_line - 1, len(self.nvim.funcs.getline(end_line))),
-        )
         self._do_evaluate(span)
 
     @pynvim.command("MagmaEvaluateOperator", sync=True)  # type: ignore
@@ -498,10 +487,6 @@ class Magma:
             DynamicPosition(
                 self.nvim, self.extmark_namespace, bufno, start - 1, 0
             ),
-            DynamicPosition(
-                self.nvim, self.extmark_namespace, bufno, end - 1, -1
-            ),
+            DynamicPosition(self.nvim, self.extmark_namespace, bufno, end - 1, -1),
         )
-        magma.outputs[span] = OutputBuffer(
-            self.nvim, self.canvas, self.options
-        )
+        magma.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,7 +152,7 @@ class Magma:
 
         return magma
 
-    @pynvim.command("MagmaInit", nargs="?", sync=True, complete='file')  # type: ignore
+    @pynvim.command("MagmaInit", nargs="?", sync=True, complete="file")  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:
         self._initialize_if_necessary()
@@ -265,6 +265,17 @@ class Magma:
             ),
         )
 
+        self._do_evaluate(span)
+
+    @pynvim.function("MagmaEvaluateRange", sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def evaulate_range(self, *args) -> None:
+        # self.nvim.current.line = f"args: {args}"
+        start_line, end_line = args[0]
+        span = (
+            (start_line - 1, 0),
+            (end_line - 1, len(self.nvim.funcs.getline(end_line))),
+        )
         self._do_evaluate(span)
 
     @pynvim.command("MagmaEvaluateOperator", sync=True)  # type: ignore
@@ -487,6 +498,10 @@ class Magma:
             DynamicPosition(
                 self.nvim, self.extmark_namespace, bufno, start - 1, 0
             ),
-            DynamicPosition(self.nvim, self.extmark_namespace, bufno, end - 1, -1),
+            DynamicPosition(
+                self.nvim, self.extmark_namespace, bufno, end - 1, -1
+            ),
         )
-        magma.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)
+        magma.outputs[span] = OutputBuffer(
+            self.nvim, self.canvas, self.options
+        )

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -143,7 +143,7 @@ class MagmaBuffer:
 
     def enter_output(self) -> None:
         if self.selected_cell is not None:
-            self.outputs[self.selected_cell].enter()
+            self.outputs[self.selected_cell].enter(self.selected_cell.end)
 
     def _get_cursor_position(self) -> Position:
         _, lineno, colno, _, _ = self.nvim.funcs.getcurpos()

--- a/rplugin/python3/magma/options.py
+++ b/rplugin/python3/magma/options.py
@@ -25,7 +25,7 @@ class MagmaOptions:
             ("magma_save_cell", os.path.join(nvim.funcs.stdpath("data"), "magma")),
             ("magma_image_provider", "none"),
             ("magma_copy_output", False),
-            ("magma_enter_output_behavior", "open_then_jump") # "open_then_jump", "open_and_jump", or "no_open"
+            ("magma_enter_output_behavior", "open_then_enter") # "open_then_enter", "open_and_enter", or "no_open"
         ]
         # fmt: on
 

--- a/rplugin/python3/magma/options.py
+++ b/rplugin/python3/magma/options.py
@@ -12,26 +12,22 @@ class MagmaOptions:
     save_path: str
     image_provider: str
     copy_output: bool
+    enter_output_behavior: str
 
     def __init__(self, nvim: Nvim):
-        self.automatically_open_output = nvim.vars.get(
-            "magma_automatically_open_output", True
-        )
-        self.wrap_output = nvim.vars.get("magma_wrap_output", False)
-        self.output_window_borders = nvim.vars.get(
-            "magma_output_window_borders", True
-        )
-        self.show_mimetype_debug = nvim.vars.get(
-            "magma_show_mimetype_debug", False
-        )
-        self.cell_highlight_group = nvim.vars.get(
-            "magma_cell_highlight_group", "CursorLine"
-        )
-        self.save_path = nvim.vars.get(
-            "magma_save_cell",
-            os.path.join(nvim.funcs.stdpath("data"), "magma"),
-        )
-        self.image_provider = nvim.vars.get("magma_image_provider", "none")
-        self.copy_output = nvim.vars.get(
-            "magma_copy_output", False
-        )
+        # fmt: off
+        CONFIG_VARS = [
+            ("magma_automatically_open_output", True),
+            ("magma_wrap_output", False),
+            ("magma_output_window_borders", True),
+            ("magma_show_mimetype_debug", False),
+            ("magma_cell_highlight_group", "CursorLine"),
+            ("magma_save_cell", os.path.join(nvim.funcs.stdpath("data"), "magma")),
+            ("magma_image_provider", "none"),
+            ("magma_copy_output", False),
+            ("magma_enter_output_behavior", "open_then_jump") # "open_then_jump", "open_and_jump", or "no_open"
+        ]
+        # fmt: on
+
+        for name, default in CONFIG_VARS:
+            setattr(self, name[6:], nvim.vars.get(name, default))

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -63,9 +63,18 @@ class OutputBuffer:
 
         return f"{old}Out[{execution_count}]: {status}"
 
-    def enter(self) -> None:
-        if self.display_window is not None:  # TODO open window if is None?
+    def enter(self, anchor: Position) -> None:
+        if self.display_window is None:
+            if self.options.enter_output_behavior == "open_then_jump":
+                self.show(anchor)
+                return
+            elif self.options.enter_output_behavior == "open_and_jump":
+                self.show(anchor)
+                self.nvim.funcs.nvim_set_current_win(self.display_window)
+                return
+        elif self.options.enter_output_behavior != "no_open":
             self.nvim.funcs.nvim_set_current_win(self.display_window)
+
 
     def clear_interface(self) -> None:
         if self.display_window is not None:

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -65,10 +65,10 @@ class OutputBuffer:
 
     def enter(self, anchor: Position) -> None:
         if self.display_window is None:
-            if self.options.enter_output_behavior == "open_then_jump":
+            if self.options.enter_output_behavior == "open_then_enter":
                 self.show(anchor)
                 return
-            elif self.options.enter_output_behavior == "open_and_jump":
+            elif self.options.enter_output_behavior == "open_and_enter":
                 self.show(anchor)
                 self.nvim.funcs.nvim_set_current_win(self.display_window)
                 return

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -72,7 +72,7 @@ class OutputBuffer:
                 self.show(anchor)
                 self.nvim.funcs.nvim_set_current_win(self.display_window)
                 return
-        elif self.options.enter_output_behavior != "no_open":
+        else:
             self.nvim.funcs.nvim_set_current_win(self.display_window)
 
 

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -75,7 +75,6 @@ class OutputBuffer:
         else:
             self.nvim.funcs.nvim_set_current_win(self.display_window)
 
-
     def clear_interface(self) -> None:
         if self.display_window is not None:
             self.nvim.funcs.nvim_win_close(self.display_window, True)
@@ -108,7 +107,7 @@ class OutputBuffer:
             lines = lines_str.rstrip().split("\n")
             actualLines = []
             for line in lines:
-                parts = line.split('\r')
+                parts = line.split("\r")
                 last = parts[-1]
                 if last != "":
                     actualLines.append(last)


### PR DESCRIPTION
Adds a configuration option to change the behavior of `:MagmaEnterOutput`.

Options are:
- "open_then_enter" (default) - open the output if it's not open, enter if it's already open
- "open_and_enter" - enter the output, if it's no open, open it and enter it
- "no_open" - the behavior as it is right now, enter the output it it's open, otherwise do nothing

Also in this pr:
- refactoring the way configuration variables are handled