### PR TITLE
Render images with `image.nvim`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.venv/

--- a/README.md
+++ b/README.md
@@ -273,13 +273,15 @@ If that parameter is omitted, then one will be automatically generated using the
 
 #### MagmaEnterOutput
 
-Enter the output window, if it is currently open. You must call this as follows:
+Configured with [magma_enter_output_behavior](#gmagma_enter_output_behavior)
+
+Enter/open the output window. You must call this as follows:
 
 ```vim
 :noautocmd MagmaEnterOutput
 ```
 
-This is escpecially useful when you have a long output (or errors) and wish to inspect it.
+This is especially useful when you have a long output (or errors) and wish to inspect it.
 
 ## Keybindings
 
@@ -305,6 +307,14 @@ nnoremap <silent> <LocalLeader>rq :noautocmd MagmaEnterOutput<CR>
 ## Customization
 
 Customization is done via variables.
+
+### `g:magma_enter_output_behavior`
+
+Configures the behavior of [MagmaEnterOutput](#magmaenteroutput)
+
+- `"open_then_enter"` (default) -- open the window if it's closed. Enter the window if it's already open
+- `"open_and_enter"` -- open and enter the window if it's closed. Otherwise enter as normal
+- `"no_open"` -- enter the window when it's open, do nothing if it's closed
 
 ### `g:magma_image_provider`
 

--- a/README.md
+++ b/README.md
@@ -373,6 +373,22 @@ We provide some `User` autocommands (see `:help User`) for further customization
 - `MagmaDeinitPre`: runs right before `MagmaDeinit` deinitialization happens for a buffer
 - `MagmaDeinitPost`: runs right after `MagmaDeinit` deinitialization happens for a buffer
 
+## Functions
+
+There is a provided function `MagmaEvaluateRange(start_line, end_line)` which evaluates the code
+between the given line numbers (inclusive). This is intended for use in scripts.
+
+### Example Usage:
+```lua
+vim.fn.MagmaEvaluateRange(1, 23)
+```
+
+```vim
+MagmaEvaluateRange(1, 23)
+" from the command line
+:call MagmaEvaluateRange(1, 23)
+```
+
 ## Extras
 
 ### Output Chunks

--- a/README.md
+++ b/README.md
@@ -214,6 +214,16 @@ Example usage:
 :MagmaShowOutput
 ```
 
+#### MagmaHideOutput
+
+This closes all currently open output windows
+
+Example usage:
+
+```vim
+:MagmaHideOutput
+```
+
 #### MagmaInterrupt
 
 Send a keyboard interrupt to the kernel. Interrupts the currently running cell and does nothing if not

--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,7 +1,0 @@
-{
-    "diagnostics.globals": [
-        "vim",
-        "require",
-        "_image"
-    ]
-}

--- a/lua/.luarc.json
+++ b/lua/.luarc.json
@@ -1,0 +1,7 @@
+{
+    "diagnostics.globals": [
+        "vim",
+        "require",
+        "_image"
+    ]
+}

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -1,0 +1,38 @@
+-- loads the image.nvim plugin and exposes methods to the python remote plugin
+local ok, image = pcall(require, "image")
+
+if not ok then
+  vim.api.nvim_err_writeln("[magma.nvim] `image.nvim` not found")
+  return
+end
+
+print('image.nvim loaded')
+
+local image_api = {}
+local images = {}
+
+image_api.from_file = function(path)
+  images[path] = image.from_file(path)
+  return path
+end
+
+image_api.render = function(identifier, geometry)
+  geometry = geometry or {}
+  images[identifier]:render(geometry)
+end
+
+image_api.clear = function(identifier)
+  images[identifier]:clear()
+end
+
+image_api.clear_all = function()
+  for _, img in pairs(images) do
+    img:clear()
+  end
+end
+
+image_api.move = function(identifier, x, y)
+  images[identifier]:move(x, y)
+end
+
+return image_api

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -19,7 +19,15 @@ end
 
 image_api.render = function(identifier, geometry)
   geometry = geometry or {}
-  images[identifier]:render(geometry)
+  local img = images[identifier]
+
+  -- a way to render images in windows when only their buffer is set
+  if img.buffer and not img.window then
+    local buf_win = vim.fn.getbufinfo(img.buffer)[1].windows
+    if #buf_win > 0 then img.window = buf_win[1] end
+  end
+
+  img:render(geometry)
 end
 
 image_api.clear = function(identifier)

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -6,8 +6,6 @@ if not ok then
   return
 end
 
-print('image.nvim loaded')
-
 local image_api = {}
 local images = {}
 local utils = {}

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -10,9 +10,10 @@ print('image.nvim loaded')
 
 local image_api = {}
 local images = {}
+local utils = {}
 
-image_api.from_file = function(path)
-  images[path] = image.from_file(path)
+image_api.from_file = function(path, opts)
+  images[path] = image.from_file(path, opts or {})
   return path
 end
 
@@ -35,4 +36,22 @@ image_api.move = function(identifier, x, y)
   images[identifier]:move(x, y)
 end
 
-return image_api
+image_api.update_window = function(identifier, window)
+  local img = images[identifier]
+  img.window = window
+  img:clear()
+end
+
+image_api.image_size = function(identifier)
+  local img = images[identifier]
+  return { width = img.image_width, height = img.image_height }
+end
+
+------ utils --------
+
+utils.cell_size = function()
+  local size = require("image.utils.term").get_size()
+  return { width = size.cell_width, height = size.cell_height }
+end
+
+return { image_api = image_api, image_utils = utils }

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -2,7 +2,7 @@
 local ok, image = pcall(require, "image")
 
 if not ok then
-  vim.api.nvim_err_writeln("[magma.nvim] `image.nvim` not found")
+  vim.api.nvim_err_writeln("[Magma] `image.nvim` not found")
   return
 end
 
@@ -29,8 +29,6 @@ image_api.render = function(identifier, geometry)
   if img.window and vim.api.nvim_win_is_valid(img.window) then
     img:render(geometry)
   end
-
-  -- img:render(geometry)
 end
 
 image_api.clear = function(identifier)

--- a/lua/load_image_nvim.lua
+++ b/lua/load_image_nvim.lua
@@ -25,7 +25,12 @@ image_api.render = function(identifier, geometry)
     if #buf_win > 0 then img.window = buf_win[1] end
   end
 
-  img:render(geometry)
+  -- only render when the window is visible
+  if img.window and vim.api.nvim_win_is_valid(img.window) then
+    img:render(geometry)
+  end
+
+  -- img:render(geometry)
 end
 
 image_api.clear = function(identifier)
@@ -40,12 +45,6 @@ end
 
 image_api.move = function(identifier, x, y)
   images[identifier]:move(x, y)
-end
-
-image_api.update_window = function(identifier, window)
-  local img = images[identifier]
-  img.window = window
-  img:clear()
 end
 
 image_api.image_size = function(identifier)

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -152,7 +152,7 @@ class Magma:
 
         return magma
 
-    @pynvim.command("MagmaInit", nargs="?", sync=True, complete='file')  # type: ignore
+    @pynvim.command("MagmaInit", nargs="?", sync=True, complete="file")  # type: ignore
     @nvimui  # type: ignore
     def command_init(self, args: List[str]) -> None:
         self._initialize_if_necessary()
@@ -265,6 +265,17 @@ class Magma:
             ),
         )
 
+        self._do_evaluate(span)
+
+    @pynvim.function("MagmaEvaluateRange", sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def evaulate_range(self, *args) -> None:
+        # self.nvim.current.line = f"args: {args}"
+        start_line, end_line = args[0]
+        span = (
+            (start_line - 1, 0),
+            (end_line - 1, len(self.nvim.funcs.getline(end_line))),
+        )
         self._do_evaluate(span)
 
     @pynvim.command("MagmaEvaluateOperator", sync=True)  # type: ignore
@@ -487,6 +498,10 @@ class Magma:
             DynamicPosition(
                 self.nvim, self.extmark_namespace, bufno, start - 1, 0
             ),
-            DynamicPosition(self.nvim, self.extmark_namespace, bufno, end - 1, -1),
+            DynamicPosition(
+                self.nvim, self.extmark_namespace, bufno, end - 1, -1
+            ),
         )
-        magma.outputs[span] = OutputBuffer(self.nvim, self.canvas, self.options)
+        magma.outputs[span] = OutputBuffer(
+            self.nvim, self.canvas, self.options
+        )

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -332,6 +332,15 @@ class Magma:
         magma.should_open_display_window = True
         self._update_interface()
 
+    @pynvim.command("MagmaHideOutput", nargs=0, sync=True)  # type: ignore
+    @nvimui  # type: ignore
+    def command_hide_output(self) -> None:
+        magma = self._get_magma(True)
+        assert magma is not None
+
+        magma.should_open_display_window = False
+        self._clear_interface()
+
     @pynvim.command("MagmaSave", nargs="?", sync=True)  # type: ignore
     @nvimui  # type: ignore
     def command_save(self, args: List[str]) -> None:

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -63,13 +63,13 @@ class Magma:
 
     def _set_autocommands(self) -> None:
         self.nvim.command("augroup magma")
-        self.nvim.command("  autocmd CursorMoved  * call MagmaOnCursorMoved()")
-        self.nvim.command("  autocmd CursorMovedI * call MagmaOnCursorMoved()")
-        self.nvim.command("  autocmd WinScrolled  * call MagmaOnWinScrolled()")
-        self.nvim.command("  autocmd BufEnter     * call MagmaUpdateInterface()")
-        self.nvim.command("  autocmd BufLeave     * call MagmaClearInterface()")
-        self.nvim.command("  autocmd BufUnload    * call MagmaOnBufferUnload()")
-        self.nvim.command("  autocmd ExitPre      * call MagmaOnExitPre()")
+        self.nvim.command("autocmd CursorMoved  * call MagmaOnCursorMoved()")
+        self.nvim.command("autocmd CursorMovedI * call MagmaOnCursorMoved()")
+        self.nvim.command("autocmd WinScrolled  * call MagmaOnWinScrolled()")
+        self.nvim.command("autocmd BufEnter     * call MagmaUpdateInterface()")
+        self.nvim.command("autocmd BufLeave     * call MagmaClearInterface()")
+        self.nvim.command("autocmd BufUnload    * call MagmaOnBufferUnload()")
+        self.nvim.command("autocmd ExitPre      * call MagmaOnExitPre()")
         self.nvim.command("augroup END")
 
     def _deinitialize(self) -> None:
@@ -122,7 +122,9 @@ class Magma:
 
         magma.on_cursor_moved(scrolled)
 
-    def _ask_for_choice(self, preface: str, options: List[str]) -> Optional[str]:
+    def _ask_for_choice(
+        self, preface: str, options: List[str]
+    ) -> Optional[str]:
         index = self.nvim.funcs.inputlist(
             [preface]
             + [f"{i+1}. {option}" for i, option in enumerate(options)]

--- a/rplugin/python3/magma/__init__.py
+++ b/rplugin/python3/magma/__init__.py
@@ -282,7 +282,6 @@ class Magma:
         self._initialize_if_necessary()
 
         self.nvim.options["operatorfunc"] = "MagmaOperatorfunc"
-        self.nvim.out_write("g@\n")
 
     @pynvim.command("MagmaEvaluateLine", nargs=0, sync=True)  # type: ignore
     @nvimui  # type: ignore

--- a/rplugin/python3/magma/images.py
+++ b/rplugin/python3/magma/images.py
@@ -2,7 +2,7 @@ import math
 from typing import Set
 from abc import ABC, abstractmethod
 
-from pynvim import Nvim
+from pynvim import Nvim, logging
 
 from magma.utils import MagmaException
 
@@ -128,7 +128,9 @@ class ImageNvimCanvas(Canvas):
 
     def init(self) -> None:
         self.nvim.exec_lua("_image = require('load_image_nvim').image_api")
-        self.nvim.exec_lua("_image_utils = require('load_image_nvim').image_utils")
+        self.nvim.exec_lua(
+            "_image_utils = require('load_image_nvim').image_utils"
+        )
         self.image_api = self.nvim.lua._image
         self.image_utils = self.nvim.lua._image_utils
 
@@ -159,7 +161,7 @@ class ImageNvimCanvas(Canvas):
     def img_height(self, identifier: str) -> int:
         img_size_px = self.image_api.image_size(identifier)
         cell_size_px = self.image_utils.cell_size()
-        return math.ceil(img_size_px['height'] / cell_size_px['height'])
+        return math.ceil(img_size_px["height"] / cell_size_px["height"])
 
     def add_image(
         self,
@@ -191,4 +193,9 @@ def get_canvas_given_provider(name: str, nvim: Nvim) -> Canvas:
     elif name == "image.nvim":
         return ImageNvimCanvas(nvim)
     else:
-        raise MagmaException(f"Unknown image provider: '{name}'")
+        nvim.api.notify(
+            f"[Magma] unknown image provider: `{name}`",
+            logging.ERROR,
+            {"title": "Magma"},
+        )
+        return NoCanvas()

--- a/rplugin/python3/magma/images.py
+++ b/rplugin/python3/magma/images.py
@@ -32,7 +32,7 @@ class Canvas(ABC):
 
         This is called only when a redraw is necessary -- so, if desired, it
         can be implemented so that `clear` and `add_image` only queue images as
-        to be drawn, and `present` actually performs the operaetions, in order
+        to be drawn, and `present` actually performs the operations, in order
         to reduce flickering.
         """
 
@@ -102,164 +102,13 @@ class NoCanvas(Canvas):
     ) -> None:
         pass
 
-
-class UeberzugCanvas(Canvas):
-    ueberzug_canvas: "ueberzug.Canvas"  # type: ignore
-
-    identifiers: Dict[str, "ueberzug.Placement"]  # type: ignore
-
-    _visible: Set[str]
-    _to_make_visible: Set[str]
-    _to_make_invisible: Set[str]
-
-    def __init__(self) -> None:
-        import ueberzug.lib.v0 as ueberzug
-
-        self.ueberzug_canvas = ueberzug.Canvas()
-        self.identifiers = {}
-
-        self._visible = set()
-        self._to_make_visible = set()
-        self._to_make_invisible = set()
-
-    def init(self) -> None:
-        self.ueberzug_canvas.__enter__()
-
-    def deinit(self) -> None:
-        if len(self.identifiers) > 0:
-            self.ueberzug_canvas.__exit__()
-
-    def present(self) -> None:
-        import ueberzug.lib.v0 as ueberzug
-
-        self._to_make_invisible.difference_update(self._to_make_visible)
-        for identifier in self._to_make_invisible:
-            self.identifiers[
-                identifier
-            ].visibility = ueberzug.Visibility.INVISIBLE
-        for identifier in self._to_make_visible:
-            self.identifiers[
-                identifier
-            ].visibility = ueberzug.Visibility.VISIBLE
-            self._visible.add(identifier)
-        self._to_make_invisible.clear()
-        self._to_make_visible.clear()
-
-    def clear(self) -> None:
-        for identifier in self._visible:
-            self._to_make_invisible.add(identifier)
-        self._visible.clear()
-
-    def add_image(
-        self,
-        path: str,
-        identifier: str,
-        x: int,
-        y: int,
-        width: int,
-        height: int,
-    ) -> None:
-        import ueberzug.lib.v0 as ueberzug
-
-        if width > 0 and height > 0:
-            identifier += f"-{os.getpid()}-{x}-{y}-{width}-{height}"
-
-            if identifier in self.identifiers:
-                img = self.identifiers[identifier]
-            else:
-                img = self.ueberzug_canvas.create_placement(
-                    identifier,
-                    x=x,
-                    y=y,
-                    width=width,
-                    height=height,
-                    scaler=ueberzug.ScalerOption.FIT_CONTAIN.value,
-                )
-                self.identifiers[identifier] = img
-            img.path = path
-
-            self._to_make_visible.add(identifier)
-
-
-class KittyImage:
-    # Adapted from https://sw.kovidgoyal.net/kitty/graphics-protocol/
-
-    def __init__(
-        self,
-        id: int,
-        path: str,
-        row: int,
-        col: int,
-        width: int,
-        height: int,
-        nvim: Nvim,
-    ):
-        self.id = id
-        self.path = path
-        self.row = row
-        self.col = col
-        self.width = width
-        self.height = height
-        self.nvim = nvim
-
-    def serialize_gr_command(self, **cmd):  # type: ignore
-        payload = cmd.pop("payload", None)
-        cmd = ",".join("{}={}".format(k, v) for k, v in cmd.items())  # type: ignore
-        ans = []  # type: ignore
-        w = ans.append
-        w(b"\033_G"), w(cmd.encode("ascii"))  # type: ignore
-        if payload:
-            w(b";")
-            w(payload)
-        w(b"\033\\")
-        ans = b"".join(ans)  # type: ignore
-        if "tmux" in os.environ["TERM"]:
-            ans = b"\033Ptmux;" + ans.replace(b"\033", b"\033\033") + b"\033\\"  # type: ignore
-        return ans
-
-    def write_chunked(self, **cmd):  # type: ignore
-        from base64 import standard_b64encode
-
-        data = standard_b64encode(cmd.pop("data"))
-        while data:
-            chunk, data = data[:4096], data[4096:]
-            m = 1 if data else 0
-            self.nvim.lua.stdout.write(
-                self.serialize_gr_command(payload=chunk, m=m, **cmd)  # type: ignore
-            )
-            cmd.clear()
-
-    def show(self) -> None:
-        with open(self.path, "rb") as f:
-            self.write_chunked(  # type: ignore
-                a="T",  # transmit directly to the terminal
-                i=self.id,
-                f=100,  # for now, only png
-                v=self.height,
-                s=self.width,
-                C=1,
-                z=10,
-                q=2,
-                data=f.read(),
-            )
-
-    def hide(self) -> None:
-        self.nvim.lua.stdout.write(
-            self.serialize_gr_command(  # type: ignore
-                i=self.id,
-                a="d",  # remove image
-                q=2,
-            )
-        )
-
-
-class Kitty(Canvas):
+# I think this class will end up being calls to equivalent lua functions in some lua file
+# somewhere
+class ImageNvimCanvas(Canvas):
     nvim: Nvim
-    images: Dict[str, KittyImage]
     to_make_visible: Set[str]
     to_make_invisible: Set[str]
     visible: Set[str]
-    next_id: int
 
     def __init__(self, nvim: Nvim):
         self.nvim = nvim
@@ -268,23 +117,28 @@ class Kitty(Canvas):
         self.to_make_visible = set()
         self.to_make_invisible = set()
         self.next_id = 0
-        nvim.exec_lua(
-            """
-            local fd = vim.loop.new_pipe(false)
-            fd:open(1)
-            local function write(data)
-                    fd:write(data)
-            end
-
-            stdout = {write = write}
-        """
-        )
 
     def init(self) -> None:
-        pass
+        # TODO:
+        # there's a better way to call lua functions, I think that I have to put those lua functions
+        # in a different spot tho, like a special folder
+        self.nvim.exec_lua("""
+            local ok, image pcall(require, 'image')
+            Image = {}
+            if not ok then
+                nvim.err_writeln('[magme-nvim]: image.nvim was not found')
+            else
+                Image.api = image
+                Image.images = {}
+            end
+        """)
 
     def deinit(self) -> None:
-        pass
+        self.nvim.exec_lua("""
+            for key, img in ipairs(Image.images) do
+                img:clear()
+            end
+        """)
 
     def present(self) -> None:
         # images to both show and hide should be ignored
@@ -293,37 +147,16 @@ class Kitty(Canvas):
         )
         self.to_make_invisible.difference_update(self.to_make_visible)
         for identifier in self.to_make_invisible:
+            # TODO: hide image
+            # self.nvim.async_call(hide_fn, self.images[identifier])
+            pass
 
-            def hide_fn(image: KittyImage) -> None:
-                image.hide()
-                # we need the sleep here, otherwise the escape codes might
-                # `spill` over into the buffer when doing
-                # several rapid operations consectively
-                time.sleep(0.01)
-
-            self.nvim.async_call(hide_fn, self.images[identifier])
         for identifier in to_work_on:
-            image = self.images[identifier]
+            # TODO: move or show
+            # image = self.images[identifier]
+            # self.nvim.async_call(fn, self.nvim, image)
+            pass
 
-            def fn(nvim: Nvim, image: KittyImage) -> None:
-                eventignore_save = nvim.options["eventignore"]
-                nvim.options["eventignore"] = "all"
-
-                org_position = nvim.current.window.cursor
-                # We need to move the cursor to the place where we want to
-                # place the image.
-                # We need to make sure we are still in the buffer.
-                nvim.current.window.cursor = (
-                    min(image.row + 1, len(nvim.current.buffer)),
-                    image.col,
-                )
-                image.show()
-                time.sleep(0.01)
-
-                nvim.current.window.cursor = org_position
-                nvim.options["eventignore"] = eventignore_save
-
-            self.nvim.async_call(fn, self.nvim, image)
         self.visible.update(self.to_make_visible)
         self.to_make_invisible.clear()
         self.to_make_visible.clear()
@@ -342,6 +175,15 @@ class Kitty(Canvas):
         width: int,
         height: int,
     ) -> None:
+
+        self.nvim.exec_lua(f"""
+        Image.images[{identifier}]= api.from_file("https://gist.ro/s/remote.png", {{
+          id = "{identifier}", -- optional, defaults to a random string
+          window = 1000, -- optional, binds image to a window and its bounds
+          buffer = 1000, -- optional, binds image to a buffer (paired with window binding)
+          with_virtual_padding = true, -- optional, pads vertically with extmarks
+        }})
+        """)
         if identifier not in self.images:
             self.images[identifier] = KittyImage(
                 id=self.next_id,
@@ -361,9 +203,7 @@ class Kitty(Canvas):
 def get_canvas_given_provider(name: str, nvim: Nvim) -> Canvas:
     if name == "none":
         return NoCanvas()
-    elif name == "ueberzug":
-        return UeberzugCanvas()
-    elif name == "kitty":
-        return Kitty(nvim)
+    elif name == "image.nvim":
+        return ImageNvimCanvas(nvim)
     else:
         raise MagmaException(f"Unknown image provider: '{name}'")

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -143,6 +143,8 @@ class MagmaBuffer:
 
     def enter_output(self) -> None:
         if self.selected_cell is not None:
+            if self.options.enter_output_behavior != "no_open":
+                self.should_open_display_window = True
             self.outputs[self.selected_cell].enter(self.selected_cell.end)
 
     def _get_cursor_position(self) -> Position:
@@ -207,9 +209,8 @@ class MagmaBuffer:
 
         if self.options.automatically_open_output:
             self.should_open_display_window = True
-        else:
-            if self.selected_cell != selected_cell:
-                self.should_open_display_window = False
+        elif self.selected_cell != selected_cell:
+            self.should_open_display_window = False
 
         self.selected_cell = selected_cell
 

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -224,11 +224,8 @@ class MagmaBuffer:
 
         if self.selected_cell == selected_cell and selected_cell is not None:
             if selected_cell.end.lineno < self.nvim.funcs.line("w$") and self.should_open_display_window and scrolled:
-                if self.display_window is not None: # and self.nvim.funcs.winbufnr(self.display_window) != -1:
-                    self.nvim.funcs.nvim_win_close(self.display_window, True)
-                    self.canvas.clear()
-                    self.display_window = None
-                self._show_outputs(self.outputs[selected_cell], selected_cell.end)
+                self.clear_interface()
+                self._show_selected(selected_cell)
                 self.canvas.present()
             return
 

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -143,7 +143,7 @@ class MagmaBuffer:
 
     def enter_output(self) -> None:
         if self.selected_cell is not None:
-            self.outputs[self.selected_cell].enter()
+            self.outputs[self.selected_cell].enter(self.selected_cell.end)
 
     def _get_cursor_position(self) -> Position:
         _, lineno, colno, _, _ = self.nvim.funcs.getcurpos()

--- a/rplugin/python3/magma/magmabuffer.py
+++ b/rplugin/python3/magma/magmabuffer.py
@@ -219,6 +219,21 @@ class MagmaBuffer:
 
         self.updating_interface = False
 
+    def on_cursor_moved(self, scrolled=False) -> None:
+        selected_cell = self._get_selected_span()
+
+        if self.selected_cell == selected_cell and selected_cell is not None:
+            if selected_cell.end.lineno < self.nvim.funcs.line("w$") and self.should_open_display_window and scrolled:
+                if self.display_window is not None: # and self.nvim.funcs.winbufnr(self.display_window) != -1:
+                    self.nvim.funcs.nvim_win_close(self.display_window, True)
+                    self.canvas.clear()
+                    self.display_window = None
+                self._show_outputs(self.outputs[selected_cell], selected_cell.end)
+                self.canvas.present()
+            return
+
+        self.update_interface()
+
     def _show_selected(self, span: Span) -> None:
         if span.begin.lineno == span.end.lineno:
             self.nvim.funcs.nvim_buf_add_highlight(

--- a/rplugin/python3/magma/options.py
+++ b/rplugin/python3/magma/options.py
@@ -25,7 +25,7 @@ class MagmaOptions:
             ("magma_save_cell", os.path.join(nvim.funcs.stdpath("data"), "magma")),
             ("magma_image_provider", "none"),
             ("magma_copy_output", False),
-            ("magma_enter_output_behavior", "open_then_jump") # "open_then_jump", "open_and_jump", or "no_open"
+            ("magma_enter_output_behavior", "open_then_enter") # "open_then_enter", "open_and_enter", or "no_open"
         ]
         # fmt: on
 

--- a/rplugin/python3/magma/options.py
+++ b/rplugin/python3/magma/options.py
@@ -12,26 +12,22 @@ class MagmaOptions:
     save_path: str
     image_provider: str
     copy_output: bool
+    enter_output_behavior: str
 
     def __init__(self, nvim: Nvim):
-        self.automatically_open_output = nvim.vars.get(
-            "magma_automatically_open_output", True
-        )
-        self.wrap_output = nvim.vars.get("magma_wrap_output", False)
-        self.output_window_borders = nvim.vars.get(
-            "magma_output_window_borders", True
-        )
-        self.show_mimetype_debug = nvim.vars.get(
-            "magma_show_mimetype_debug", False
-        )
-        self.cell_highlight_group = nvim.vars.get(
-            "magma_cell_highlight_group", "CursorLine"
-        )
-        self.save_path = nvim.vars.get(
-            "magma_save_cell",
-            os.path.join(nvim.funcs.stdpath("data"), "magma"),
-        )
-        self.image_provider = nvim.vars.get("magma_image_provider", "none")
-        self.copy_output = nvim.vars.get(
-            "magma_copy_output", False
-        )
+        # fmt: off
+        CONFIG_VARS = [
+            ("magma_automatically_open_output", True),
+            ("magma_wrap_output", False),
+            ("magma_output_window_borders", True),
+            ("magma_show_mimetype_debug", False),
+            ("magma_cell_highlight_group", "CursorLine"),
+            ("magma_save_cell", os.path.join(nvim.funcs.stdpath("data"), "magma")),
+            ("magma_image_provider", "none"),
+            ("magma_copy_output", False),
+            ("magma_enter_output_behavior", "open_then_jump") # "open_then_jump", "open_and_jump", or "no_open"
+        ]
+        # fmt: on
+
+        for name, default in CONFIG_VARS:
+            setattr(self, name[6:], nvim.vars.get(name, default))

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import List, Optional
 
 from pynvim import Nvim
 from pynvim.api import Buffer
@@ -119,7 +119,8 @@ class OutputBuffer:
                 lines_str += chunktext
                 lineno += chunktext.count("\n")
                 virtual_lines += virt_lines
-            lines = lines_str.split("\n")
+
+            lines = handle_progress_bars(lines_str)
             lineno = len(lines)
         else:
             lines = [lines_str]
@@ -151,3 +152,18 @@ class OutputBuffer:
                 },
             )
             self.canvas.present()
+
+def handle_progress_bars(line_str: str) -> List[str]:
+    """ Progress bars like tqdm use special chars (`\\r`) and some trick to work
+    This is fine for the terminal, but in a text editor we have so do some extra work
+    """
+    actual_lines = []
+    lines = line_str.split("\n")
+    for line in lines:
+        parts = line.split('\r')
+        last = parts[-1]
+        if last != "":
+            actual_lines.append(last)
+            lines = actual_lines
+
+    return actual_lines

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -63,9 +63,18 @@ class OutputBuffer:
 
         return f"{old}Out[{execution_count}]: {status}"
 
-    def enter(self) -> None:
-        if self.display_window is not None:  # TODO open window if is None?
+    def enter(self, anchor: Position) -> None:
+        if self.display_window is None:
+            if self.options.enter_output_behavior == "open_then_jump":
+                self.show(anchor)
+                return
+            elif self.options.enter_output_behavior == "open_and_jump":
+                self.show(anchor)
+                self.nvim.funcs.nvim_set_current_win(self.display_window)
+                return
+        elif self.options.enter_output_behavior != "no_open":
             self.nvim.funcs.nvim_set_current_win(self.display_window)
+
 
     def clear_interface(self) -> None:
         if self.display_window is not None:

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -65,10 +65,10 @@ class OutputBuffer:
 
     def enter(self, anchor: Position) -> None:
         if self.display_window is None:
-            if self.options.enter_output_behavior == "open_then_jump":
+            if self.options.enter_output_behavior == "open_then_enter":
                 self.show(anchor)
                 return
-            elif self.options.enter_output_behavior == "open_and_jump":
+            elif self.options.enter_output_behavior == "open_and_enter":
                 self.show(anchor)
                 self.nvim.funcs.nvim_set_current_win(self.display_window)
                 return

--- a/rplugin/python3/magma/outputbuffer.py
+++ b/rplugin/python3/magma/outputbuffer.py
@@ -1,4 +1,3 @@
-import math
 from typing import Optional
 
 from pynvim import Nvim

--- a/rplugin/python3/magma/outputchunks.py
+++ b/rplugin/python3/magma/outputchunks.py
@@ -122,12 +122,12 @@ class ImageOutputChunk(OutputChunk):
         shape: Tuple[int, int, int, int],
         canvas: Canvas,
     ) -> Tuple[str, int]:
-        x, _y, win_w, win_h = shape
+        _x, _y, win_w, win_h = shape
 
         img = canvas.add_image(
             self.img_path,
             self.img_checksum,
-            x=x,
+            x=0,
             y=lineno + 1,
             bufnr=bufnr,
         )


### PR DESCRIPTION
_this will stay in draft state until todo items are done_ 

## The What

[image.nvim](https://github.com/3rd/image.nvim) is a NeoVim plugin that adds image support. This PR uses the plugin like a library to render image outputs.

This PR also incorporates some performance improvements that were proposed in #43, with a few bugs ironed out. 

## The Why

1. Consistency. Before, we had our own image implementations. There was a kitty graphics image implementation, and an uberzug image implementation. I never used uberzug, but the kitty implementation was inconsistent at best, and buggy at worst for me. I've found image.nvim's implementation to be very solid, and the maintainer very interested in fixing bugs that I've brought up.

2. Maintainability. Handling our own image rendering is far less maintainable than simply outsourcing the heavy lifting to another plugin. 

3. Image.nvim has sixel support on the road map. I'm not sure if/when that'll be, but we'll get it for free if it even happens.

## Considerations

- Image.nvim is very new, and subject to change. The API that we're using might change. Modern package managers can pin versions, so I'm not too concerned. But this is still something to watch out for. 

- I've just ripped out the old image backends, but it might be worth to keep them in with a deprecation notice for a month or so to let people migrate to image.nvim without everything breaking right away.

## todo
- [ ] Merge the other changes this PR includes. Currently this PR contains changes that are proposed in #112 #110 and #109 
- [ ] waiting on an image.nvim api update adding cropping functionality to fix a bug where images display over the status bar
- [ ] Update the README
- [x] about a week or two of testing this in action
- [ ] possibly add old image providers back, keep them in with a deprecation warning for a month or so
- [x] round one of bug fixing